### PR TITLE
VCL changes to make things more cacheable and avoid unnecessary

### DIFF
--- a/config/fastly/deliver.vcl
+++ b/config/fastly/deliver.vcl
@@ -1,7 +1,9 @@
 # Remove the exact PHP Version from the response for more security (e.g. 404 pages)
 unset resp.http.x-powered-by;
 
-if (resp.http.sw-invalidation-states) {
+# We use fastly.ff.visits_this_service to avoid running this logic on shield nodes. We only need to
+# run it on edge nodes
+if (fastly.ff.visits_this_service == 0 && resp.http.sw-invalidation-states) {
   # invalidation headers are only for internal use
   unset resp.http.sw-invalidation-states;
 

--- a/config/fastly/hit.vcl
+++ b/config/fastly/hit.vcl
@@ -1,5 +1,5 @@
-if (req.http.cookie ~ "sw-states=") {
-   set req.http.states = regsub(req.http.cookie, "^.*?sw-states=([^;]*);*.*$", "\1");
+if (req.http.cookie:sw-states) {
+   set req.http.states = req.http.cookie:sw-states;
 
    if (req.http.states ~ "logged-in" && obj.http.sw-invalidation-states ~ "logged-in" ) {
       return (pass);

--- a/config/fastly/recv.vcl
+++ b/config/fastly/recv.vcl
@@ -41,12 +41,6 @@ if (req.http.x-forwarded-for) {
     set req.http.X-Forwarded-For = client.ip;
 }
 
-# Normally, you should consider requests other than GET and HEAD to be uncacheable
-# (to this we add the special FASTLYPURGE method)
-if (req.method != "HEAD" && req.method != "GET" && req.method != "FASTLYPURGE") {
-  return(pass);
-}
-
 # Don't cache Authenticate & Authorization
 if (req.http.Authenticate || req.http.Authorization) {
     return (pass);
@@ -57,5 +51,3 @@ if (req.http.Authenticate || req.http.Authorization) {
 if (req.url.path ~ "^/(checkout|account|admin|api)(/.*)?$") {
     return (pass);
 }
-
-return (lookup);


### PR DESCRIPTION
I have made a couple changes to the stock Fastly VCL. Some of the issues that I have observed are

- Early returns e.g. return(lookup) at the end of recv.vcl. This will do an early return and avoid shielding logic causing worse cache hit ratios
- Simplified pieces of code with cookie accessors e.g. req.http.Cookie:sw_states.
- Corrected the deliver.vcl which would have resulted in no caching on Fastly edge nodes (only on shield)