### PR TITLE
optimize cache clear during deployments for dedicated generation 2

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -140,7 +140,12 @@ hooks:
 
         # optional: run migration automatically with deploy
         bin/console database:migrate --all
-        bin/console cache:clear
+
+        # run cache clear commands, on grid environments this should run in the deploy hook,
+        # on dedicated generation 2, it will run as part of the pre_start hook (to be set up by Platform.sh support)
+        if [ "$PLATFORM_MODE" != enterprise ]; then
+            sh prestart_cacheclear.sh
+        fi
 
         ./setup-fastly.sh
 

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -143,7 +143,7 @@ hooks:
 
         # run cache clear commands, on grid environments this should run in the deploy hook,
         # on dedicated generation 2, it will run as part of the pre_start hook (to be set up by Platform.sh support)
-        if [ "$PLATFORM_MODE" != enterprise ]; then
+        if [ "$PLATFORM_REGISTRY_NUMBER" ]; then
             sh prestart_cacheclear.sh
         fi
 

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -143,8 +143,11 @@ hooks:
 
         # run cache clear commands, on grid environments this should run in the deploy hook,
         # on dedicated generation 2, it will run as part of the pre_start hook (to be set up by Platform.sh support)
-        if [ "$PLATFORM_REGISTRY_NUMBER" ]; then
+        if [ -z "$PLATFORM_REGISTRY_NUMBER" ]; then
             sh prestart_cacheclear.sh
+        else
+            # on dedicated gen 2, we need to explictly clear the redis cache since redis is not available during pre_start
+            bin/console cache:pool:clear cache.object
         fi
 
         ./setup-fastly.sh

--- a/bin/prestart_cacheclear.sh
+++ b/bin/prestart_cacheclear.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+# This script is run as part of the .platform.app.yaml deployment step
+# On dedicated generation 2 clusters, this should be setup by Platform.sh team as part of pre_start hook
+
+set -e
+
+echo "removing var/cache/${APP_ENV}_*/*.*"
+rm -Rf var/cache/${APP_ENV}_*/*.*
+
+echo "clearing application cache"
+php bin/console cache:clear
+
+echo "done executing pre_start cache clear"


### PR DESCRIPTION
In dedicated environments where you have multiple nodes the deploy hook only runs once, while the pre_start hook (which is specific to dedicated gen 2) is executed on all nodes. 

`$PLATFORM_REGISTRY_NUMBER` is an environment variable that is only present on dedicated generation 2 clusters (but not on grid nor on dedicated generation 3)