### PR TITLE
Expliciting PASS for csrf requests

### DIFF
--- a/config/fastly/recv.vcl
+++ b/config/fastly/recv.vcl
@@ -51,6 +51,6 @@ if (req.http.Authenticate || req.http.Authorization) {
 
 # Always pass these paths directly to php without caching
 # Note: virtual URLs might bypass this rule (e.g. /en/checkout)
-if (req.url.path ~ "^/(checkout|account|admin|api)(/.*)?$") {
+if (req.url.path ~ "^/(checkout|account|admin|api|csrf)(/.*)?$") {
     return (pass);
 }


### PR DESCRIPTION
csrf requests must always pass, no need to even lookup