### PR TITLE
Removing the early return(pass)

### DIFF
--- a/config/fastly/fetch.vcl
+++ b/config/fastly/fetch.vcl
@@ -4,5 +4,3 @@ if (beresp.http.cache-control ~ "public") {
 
   return (deliver);
 }
-
-return (pass);


### PR DESCRIPTION
Early return(pass) removes all the default Fastly logic. That should not be done.
Furthermore, this early return(pass) prevents any caching of the Shopware assets, that are returned without a cache-control: public.