### PR TITLE
Remove early returns and prevent caching of objects with no cache-control headers

### DIFF
--- a/config/fastly/fetch.vcl
+++ b/config/fastly/fetch.vcl
@@ -1,6 +1,17 @@
+# Pass immediately if x-pass is present
+if (req.http.x-pass) {
+  return (pass);
+}
+
 # remove set cookie headers to make responses cachable
 if (beresp.http.cache-control ~ "public") {
   unset beresp.http.set-cookie;
+}
 
-  return (deliver);
+# If the object is coming with no Expires, Surrogate-Control or Cache-Control headers we assume it's a misconfiguration
+# and should not cache it. This is to prevent inadventently caching private data
+if (!beresp.http.Expires && !beresp.http.Surrogate-Control ~ "max-age" && !beresp.http.Cache-Control ~ "(s-maxage|max-age)") {
+  # Varnish sets default TTL if none of the headers above are present. If not set we want to make sure we don't cache it
+  set beresp.ttl = 0s;
+  set beresp.cacheable = false;
 }

--- a/config/fastly/recv.vcl
+++ b/config/fastly/recv.vcl
@@ -1,3 +1,8 @@
+# Don't allow clients to force a pass
+if (req.restarts == 0) {
+  unset req.http.x-pass;
+}
+
 # Enable Fastly authentification for single purges
 set req.http.Fastly-Purge-Requires-Auth = "1";
 
@@ -46,11 +51,11 @@ if (req.http.x-forwarded-for) {
 
 # Don't cache Authenticate & Authorization
 if (req.http.Authenticate || req.http.Authorization) {
-    return (pass);
+    set req.http.x-pass = "1";
 }
 
 # Always pass these paths directly to php without caching
 # Note: virtual URLs might bypass this rule (e.g. /en/checkout)
 if (req.url.path ~ "^/(checkout|account|admin|api|csrf)(/.*)?$") {
-    return (pass);
+    set req.http.x-pass = "1";
 }


### PR DESCRIPTION
This pull request has two changes

1. All early returns from recv.vcl have been changed to set a header called `req.http.x-pass`. Problem with doing return(pass) is that it skips any backend selection that you may end up doing later in the VCL processing. This is in vast majority of cases undesirable. To really take advantage of this the Paas should add a request setting object that has the action of PASS in case `req.http.x-pass` is present
2. Any object with no cache headers should not be cached. It's not necessarily against the spec to cache it however there have been numerous cases of misconfiguration where there was a server misconfig where private data was cached. This is just a safety precaution.