### PR TITLE
fix: Check if fastly executable is present and download otherwise

### DIFF
--- a/setup-fastly.sh
+++ b/setup-fastly.sh
@@ -40,12 +40,12 @@ get_md5()
 }
 
 install_fastly_cli() {
-    if [[ -d "/tmp/fastly" ]]; then
+    if [[ -f "/tmp/fastly/fastly" ]]; then
       export PATH="/tmp/fastly:$PATH"
       return
     fi
 
-    mkdir /tmp/fastly
+    mkdir -p /tmp/fastly
 
     arch=$(uname -m)
     os="linux"


### PR DESCRIPTION
closes #11