### PR TITLE
Critical fix for an issue with collapsing

### DIFF
--- a/config/fastly/fetch.vcl
+++ b/config/fastly/fetch.vcl
@@ -8,10 +8,15 @@ if (beresp.http.cache-control ~ "public") {
   unset beresp.http.set-cookie;
 }
 
+if (beresp.http.Cache-Control ~ "private|no-cache|no-store") {
+  set req.http.Fastly-Cachetype = "PRIVATE";
+  return (pass);
+}
+
 # If the object is coming with no Expires, Surrogate-Control or Cache-Control headers we assume it's a misconfiguration
 # and should not cache it. This is to prevent inadventently caching private data
 if (!beresp.http.Expires && !beresp.http.Surrogate-Control ~ "max-age" && !beresp.http.Cache-Control ~ "(s-maxage|max-age)") {
   # Varnish sets default TTL if none of the headers above are present. If not set we want to make sure we don't cache it
-  set beresp.ttl = 0s;
-  set beresp.cacheable = false;
+        set beresp.ttl = 3600s;
+        return(pass);
 }


### PR DESCRIPTION
When an object is not cacheable a return (pass) must be sent