### PR TITLE
change fastly deliver config to prevent the client from caching more efficiently

### DIFF
--- a/config/fastly/deliver.vcl
+++ b/config/fastly/deliver.vcl
@@ -8,5 +8,5 @@ if (fastly.ff.visits_this_service == 0 && resp.http.sw-invalidation-states) {
   unset resp.http.sw-invalidation-states;
 
   ## we don't want the client to cache
-  set resp.http.Cache-Control = "no-store, max-age=0";
+  set resp.http.Cache-Control = "no-cache, private";
 }

--- a/config/fastly/deliver.vcl
+++ b/config/fastly/deliver.vcl
@@ -8,5 +8,5 @@ if (fastly.ff.visits_this_service == 0 && resp.http.sw-invalidation-states) {
   unset resp.http.sw-invalidation-states;
 
   ## we don't want the client to cache
-  set resp.http.Cache-Control = "max-age=0, private";
+  set resp.http.Cache-Control = "no-store, max-age=0";
 }


### PR DESCRIPTION
The max-age=0 cache control directive is not enough from prevent the client caching.
This does not prevent the client from reserving the cached page with the browser's previous button. It is better to use the no-cache directive in this case (or no-store if we also dont want the proxy to cache).

We have a problem with this on a shopware project when we add a product to the cart in ajax then we are going to another page and then back with the browser previous button. The basket appear empty.